### PR TITLE
Fix conf.write_initial_config() to use read_file() instead of deprecated readfp()

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+osc (0.169.1-2deepin2) unstable; urgency=medium
+
+  * Apply upstream fix for python 3.12 deprecated API readfp()
+    https://github.com/openSUSE/osc/pull/1446
+
+ -- Cryolitia <liziyao@uniontech.com>  Wed, 16 Apr 2025 17:36:42 +0800
+
 osc (0.169.1-2deepin1) unstable; urgency=medium
 
   * Replace imp with importlib

--- a/debian/patches/python-3.12-deprecated-readfp.patch
+++ b/debian/patches/python-3.12-deprecated-readfp.patch
@@ -1,0 +1,14 @@
+Fix conf.write_initial_config() to use read_file() instead of deprecated readfp()
+
+Pick from: https://github.com/openSUSE/osc/pull/1446
+--- a/osc/conf.py
++++ b/osc/conf.py
+@@ -758,7 +758,7 @@
+     config.update(entries)
+     sio = StringIO(conf_template.strip() % config)
+     cp = OscConfigParser.OscConfigParser(DEFAULTS)
+-    cp.readfp(sio)
++    cp.read_file(sio)
+     cp.set(config['apiurl'], 'user', config['user'])
+     if creds_mgr_descriptor:
+         creds_mgr = creds_mgr_descriptor.create(cp)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 setuptools-60.patch
 python-3.11.patch
 python-3.12.patch
+python-3.12-deprecated-readfp.patch


### PR DESCRIPTION
Pick from: https://github.com/openSUSE/osc/pull/1446